### PR TITLE
Feature: host pool

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,9 @@
 use Mix.Config
+
+config :hackney, pool_handler: HostPool
+
+config :host_pool,
+  connection_pool: HostPool.ConnectionPool,
+  checkout_timeout: 5_000,
+  pool_type: :host,
+  limit: 10

--- a/lib/host_pool.ex
+++ b/lib/host_pool.ex
@@ -2,4 +2,151 @@ defmodule HostPool do
   @moduledoc ~S"""
   Hackney pool implementation that sets limits per host in stead of pool.
   """
+  use Supervisor
+
+  @behaviour :hackney_pool_handler
+
+  @compile {:inline, pool_name: 2}
+
+  # Supervisor settings
+  @super_parent :hackney_sup
+  @super_spec supervisor(__MODULE__, [])
+
+  # Configuration
+  @connection_pool Application.get_env(:host_pool,
+                                       :connection_pool,
+                                       HostPool.ConnectionPool)
+  @checkout_timeout Application.get_env(:host_pool, :checkout_timeout, 5_000)
+  @checkout_limit Application.get_env(:host_pool, :checkout_limit, 15_000)
+
+  # Request record parsing
+  @record_request_options 6 + 1
+
+  ### Hackney Pool Handler
+
+  @impl true
+  def start do
+    with {:ok, _pid} <- Supervisor.start_child(@super_parent, @super_spec) do
+      :ok
+    end
+  end
+
+  @impl true
+  def checkout(host, port, transport, client) do
+    # Parse options
+    options =
+      client
+      |> elem(@record_request_options)
+
+    pool_name =
+      options
+      |> Keyword.get(:pool, :default)
+
+    connect_timeout =
+      options
+      |> Keyword.get(:connect_timeout, @checkout_timeout)
+
+    checkout_limit =
+      options
+      |> Keyword.get(:checkout_limit, @checkout_limit)
+
+    # Setup references
+    checkin_ref = {host, port, transport}
+
+    owner =
+      pool_name
+      |> find_or_create_pool(checkin_ref)
+
+    # Make the call
+    result =
+      GenServer.call(
+        owner,
+        {:checkout, checkin_ref, {connect_timeout, checkout_limit}},
+        connect_timeout
+      )
+
+    # Parse the result
+    case result do
+      {:ok, socket} ->
+        {
+          :ok,
+          {pool_name, checkin_ref, owner, :return},
+          socket
+        }
+      # credo:disable-for-next-line
+      {:new,} ->
+        {
+          :error,
+          :no_socket,
+          {pool_name, checkin_ref, owner, :new}
+        }
+      error -> error
+    end
+  end
+
+  @impl true
+  def checkin(reference = {_pool, _data, owner, type}, socket) do
+    if type == :new do
+      unclaim(socket)
+    end
+
+    GenServer.call(owner, {:checkin, reference, socket})
+  end
+
+  @impl true
+  def notify(_pool, _message) do
+    # Do not notify anyone
+
+    :ok
+  end
+
+  ### Supervisor
+
+  @doc false
+  @spec start_link :: Supervisor.on_start
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init([]) do
+    Supervisor.init([], strategy: :one_for_one)
+  end
+
+  ### Pool Helpers
+
+  # Finds or creates a pool.
+  # All created pools are added to the HostPool supervisor.
+  @spec find_or_create_pool(atom, tuple) :: pid
+  defp find_or_create_pool(pool, reference) do
+    name = pool_name(pool, reference)
+    child = worker(@connection_pool, [name], id: name)
+
+    case Supervisor.start_child(__MODULE__, child) do
+      {:ok, pid} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
+  end
+
+  # @spec stop_pool(term) :: :ok | {:error, atom}
+  # defp stop_pool(id) do
+  #   Supervisor.terminate_child __MODULE__, id
+  #   Supervisor.delete_child __MODULE__, id
+  # end
+
+  # Unlinks the socket from its creator.
+  @spec unclaim(term) :: true
+  def unclaim({:sslsocket, {_, port, _, _}, _}), do: :erlang.unlink(port)
+  def unclaim(port), do: :erlang.unlink(port)
+
+  # Turns the pool and checkin_ref into an identifier.
+  @spec pool_name(atom, tuple) :: term
+  case Application.get_env(:host_pool, :pool_type, :host) do
+    :single ->
+      defp pool_name(_pool, _ref), do: :single_process_pool
+    :pool ->
+      defp pool_name(pool, _ref), do: pool
+    :host ->
+      defp pool_name(pool, {host, _, _}), do: {pool, host}
+  end
 end

--- a/test/host_pool_test.exs
+++ b/test/host_pool_test.exs
@@ -1,4 +1,156 @@
 defmodule HostPoolTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
+  defp client(options \\ []) do
+    {0, 1, 2, 3, 4, 5, 6, options}
+  end
+
+  describe "pool management" do
+    test "creates a new pool for unique id" do
+      HostPool.checkout 'pool-test-new.com', 1, :custom, client()
+
+      children = Supervisor.which_children(HostPool)
+
+      assert List.keymember?(children, {:default, 'pool-test-new.com'}, 0)
+    end
+
+    test "reuses pool for existing id" do
+      HostPool.checkout 'pool-test-reuse.com', 1, :custom, client()
+      children = Supervisor.which_children(HostPool)
+
+      HostPool.checkout 'pool-test-reuse.com', 1, :custom, client()
+      new_children = Supervisor.which_children(HostPool)
+
+      assert new_children == children
+    end
+
+    test "respects pool" do
+      HostPool.checkout 'pool-test-pool.com', 1, :custom, client(pool: :custom)
+
+      children = Supervisor.which_children(HostPool)
+
+      assert List.keymember?(children, {:custom, 'pool-test-pool.com'}, 0)
+    end
+  end
+
+  describe "checkin" do
+    test "claims port when :new (ssl)" do
+      port = 5
+      ref = {:default, 0, self(), :new}
+      socket = {:sslsocket, {0, port, 0, 0}, 0}
+
+      assert_raise ArgumentError, fn -> HostPool.checkin ref, socket end
+    end
+
+    test "claims port when :new (other)" do
+      port = 5
+      ref = {:default, 0, self(), :new}
+
+      assert_raise ArgumentError, fn -> HostPool.checkin ref, port end
+    end
+
+    test "doesn not claim port on :return (other)" do
+      owner = self()
+      ref = {:default, 0, owner, :return}
+      port = 5
+
+      :meck.new GenServer
+      :meck.expect GenServer, :call, fn
+        ^owner, {:checkin, ^ref, ^port} -> :not_claimed
+      end
+      on_exit &:meck.unload/0
+
+      assert HostPool.checkin(ref, port) == :not_claimed
+    end
+  end
+
+
+  describe "checkout" do
+    defp mock_response(ref, result, data_pid \\ nil) do
+      :meck.new GenServer, [:passthrough]
+      :meck.expect GenServer, :call, fn
+        owner, {:checkout, ^ref, options}, timeout ->
+          if data_pid do
+            send data_pid, {:mock_data, options, timeout, owner}
+          end
+
+          result
+        a, b, c -> :meck.passthrough([a, b, c])
+      end
+      on_exit &:meck.unload/0
+    end
+
+    test "creates correct reference" do
+      ref = {'pool-test-checkout.com', 1, :custom}
+      mock_response ref, :ok_ref
+
+      assert HostPool.checkout('pool-test-checkout.com', 1, :custom, client()) == :ok_ref
+    end
+
+    test "uses the correct timeout" do
+      ref = {'pool-test-checkout.com', 1, :custom}
+      mock_response ref, :ok_ref, self()
+
+      client = client(connect_timeout: 5)
+      HostPool.checkout('pool-test-checkout.com', 1, :custom, client)
+
+      {options, timeout} =
+        receive do
+          {:mock_data, options, timeout, _owner} -> {options, timeout}
+        end
+
+      assert timeout == 5
+      assert elem(options, 0) == 5
+    end
+
+    test "uses the correct checkout limit" do
+      ref = {'pool-test-checkout.com', 1, :custom}
+      mock_response ref, :ok_ref, self()
+
+      client = client(checkout_limit: 8)
+      HostPool.checkout('pool-test-checkout.com', 1, :custom, client)
+
+      checkout_limit =
+        receive do
+          {:mock_data, {_, checkout_limit}, _timeout, _owner} -> checkout_limit
+        end
+
+      assert checkout_limit == 8
+    end
+
+    test "passes along the errors" do
+      ref = {'pool-test-checkout.com', 1, :custom}
+      mock_response ref, {:error, :ref}
+
+      assert HostPool.checkout('pool-test-checkout.com', 1, :custom, client()) == {:error, :ref}
+    end
+
+    test "returns correct response for new socket" do
+      ref = {'pool-test-checkout.com', 1, :custom}
+      mock_response ref, {:new,}, self()
+
+      response = HostPool.checkout('pool-test-checkout.com', 1, :custom, client())
+
+      owner =
+        receive do
+          {:mock_data, _options, _timeout, owner} -> owner
+        end
+
+      assert response == {:error, :no_socket, {:default, ref, owner, :new}}
+    end
+
+    test "returns correct response for existing socket" do
+      ref = {'pool-test-checkout.com', 1, :custom}
+      mock_response ref, {:ok, :existing_socket}, self()
+
+      response = HostPool.checkout('pool-test-checkout.com', 1, :custom, client())
+
+      owner =
+        receive do
+          {:mock_data, _options, _timeout, owner} -> owner
+        end
+
+      assert response == {:ok, {:default, ref, owner, :return}, :existing_socket}
+    end
+  end
 end


### PR DESCRIPTION
Host pool implementation.

The connections are not mentioned by this Supervisor.
This supervisor supervises the GenServers handling the connections.

The `HostPool` allows for 3 method of storing connections:

  * `:single`, all connections, regardless of pool, are managed by the same `GenServer`.
  * `:pool`, all connections in a pool are managed by one `GenServer`.
  * `:host` (*default*), every pool has a `GenServer` per host.